### PR TITLE
Add git ignore for MacOSX and Unity metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*.meta


### PR DESCRIPTION
This project has no git ignore but having we'll need one no matter what.
