### PR TITLE
Issue with EventEmitter.Off

### DIFF
--- a/Event/EventEmitter.cs
+++ b/Event/EventEmitter.cs
@@ -57,6 +57,11 @@ namespace Wizcorp.MageSDK.Event
 		//
 		public void Off(string eventTag, Action<object, T> handler)
 		{
+			if (!eventTags.ContainsKey(eventTag))
+			{
+				return;
+			}
+
 			eventsList.RemoveHandler(eventTags[eventTag], handler);
 		}
 


### PR DESCRIPTION
# Description
- Fix a **NullReferenceException** in the event Emitter
- This error happen after a disconnection in a game I'm working on
