### PR TITLE
fixed event emitter to allow removing all listeners for a single tag

### DIFF
--- a/Mage/CommandCenter/TransportClient/CommandHTTPClient.cs
+++ b/Mage/CommandCenter/TransportClient/CommandHTTPClient.cs
@@ -33,7 +33,7 @@ namespace Wizcorp.MageSDK.Command.Client
 		public override void SetEndpoint(string baseUrl, string appName, Dictionary<string, string> headers = null)
 		{
 			endpoint = baseUrl + "/" + appName;
-			headers = new Dictionary<string, string>(headers);
+			this.headers = new Dictionary<string, string>(headers);
 		}
 
 		//


### PR DESCRIPTION
Refactored the event emitter class to allow us better control of event handlers. Now we can remove all listeners for a single tag.

Note: since we no longer use the tag system inside `EventHandlerList`, is there any reason to use it? Why not just `Dictionary` of `List` of `delegate`?
