### PR TITLE
Tomes > EmitToParents

### DIFF
--- a/Tomes/TomeArray.cs
+++ b/Tomes/TomeArray.cs
@@ -43,7 +43,7 @@ namespace Wizcorp.MageSDK.Tomes
 		//
 		private void EmitToParents(JToken oldValue)
 		{
-			if (this != root)
+			if (!ReferenceEquals(this, root))
 			{
 				Tome.EmitParentChange(Parent);
 			}

--- a/Tomes/TomeObject.cs
+++ b/Tomes/TomeObject.cs
@@ -44,7 +44,7 @@ namespace Wizcorp.MageSDK.Tomes
 		//
 		private void EmitToParents(JToken oldValue)
 		{
-			if (this != root)
+			if (!ReferenceEquals(this, root))
 			{
 				Tome.EmitParentChange(Parent);
 			}

--- a/Tomes/TomeValue.cs
+++ b/Tomes/TomeValue.cs
@@ -30,7 +30,7 @@ namespace Wizcorp.MageSDK.Tomes
 		//
 		private void EmitToParents(JToken oldValue)
 		{
-			if (!Equals(this, root))
+			if (!ReferenceEquals(this, root))
 			{
 				Tome.EmitParentChange(Parent);
 			}


### PR DESCRIPTION
# Description
We found a bug with **Tomes.EmitToParent** (related to the last merge)

With a boolean TomeValue :
* if the value is assigned to true the event is properly emitted
* if the value is assigned to false the event is not emitted at all to the parent

We found that ```!Equals(this, root)``` doesn't work properly here (probably because JValue override internally Compare or GetType).
Just replaced **Equals** by **ReferenceEquals** and now it works better.