### PR TITLE
Fix Tome's root property

### DIFF
--- a/Tomes/TomeArray.cs
+++ b/Tomes/TomeArray.cs
@@ -31,7 +31,7 @@ namespace Wizcorp.MageSDK.Tomes
 			//
 			for (var i = 0; i < data.Count; i += 1)
 			{
-				Add(Tome.Conjure(data[i], root));
+				Add(Tome.Conjure(data[i], this.root));
 			}
 
 			//

--- a/Tomes/TomeObject.cs
+++ b/Tomes/TomeObject.cs
@@ -32,7 +32,7 @@ namespace Wizcorp.MageSDK.Tomes
 			//
 			foreach (JProperty property in data.Properties())
 			{
-				Add(property.Name, Tome.Conjure(property.Value, root));
+				Add(property.Name, Tome.Conjure(property.Value, this.root));
 			}
 
 			//


### PR DESCRIPTION
# Description
I finally found why the event was not properly propagated to the top level container (JArray)
Related to a small error due to the fact that a private property and a parameter have the same name ...

The only other function where this trouble can also happen is ```ApplyOperation``` but it seems fine to me. If someone else can just double check it to be sure.

Seriously, if we plan to keep this tome implementation, we really need unit tests.