### PR TITLE
Issue with MGet (optional flag and cache)

### DIFF
--- a/Mage/Archivist/Archivist.cs
+++ b/Mage/Archivist/Archivist.cs
@@ -157,7 +157,7 @@ namespace Wizcorp.MageSDK.MageClient
 		////////////////////////////////////////////
 		//        Vault Value Manipulation        //
 		////////////////////////////////////////////
-		private void ValueSetOrDelete(JObject info)
+		private void ValueSetOrNull(JObject info)
 		{
 			var topic = (string)info["key"]["topic"];
 			var index = (JObject)info["key"]["index"];
@@ -169,7 +169,7 @@ namespace Wizcorp.MageSDK.MageClient
 			}
 			else
 			{
-				ValueDel(topic, index);
+				ValueSet(topic, index, null, null, null);
 			}
 		}
 
@@ -378,7 +378,7 @@ namespace Wizcorp.MageSDK.MageClient
 				// Parse value
 				try
 				{
-					ValueSetOrDelete((JObject)result);
+					ValueSetOrNull((JObject)result);
 				}
 				catch (Exception cacheError)
 				{
@@ -459,15 +459,14 @@ namespace Wizcorp.MageSDK.MageClient
 						string cacheKeyName = CreateCacheKey(topic, index);
 
 						// Set value to cache
-						ValueSetOrDelete(topicValue);
+						ValueSetOrNull(topicValue);
 
 						// Add value to response
 						int responseKey = realQueryKeys[cacheKeyName];
 						var cacheValue = GetCacheValue(cacheKeyName);
-						if (cacheValue != null)
-						{
-							responseArray[responseKey].Replace(cacheValue.Data);
-						}
+						var value = (cacheValue != null) ? cacheValue.Data : null;
+
+						responseArray[responseKey].Replace(value);
 					}
 				}
 				catch (Exception cacheError)
@@ -546,15 +545,14 @@ namespace Wizcorp.MageSDK.MageClient
 						string cacheKeyName = CreateCacheKey(valueTopic, valueIndex);
 
 						// Set value to cache
-						ValueSetOrDelete(topicValue);
+						ValueSetOrNull(topicValue);
 
 						// Add value to response
 						string responseKey = realQueryKeys[cacheKeyName];
 						var cacheValue = GetCacheValue(cacheKeyName);
-						if (cacheValue != null)
-						{
-							responseObject.Add(responseKey, cacheValue.Data);
-						}
+						var value = (cacheValue != null) ? cacheValue.Data : null;
+
+						responseObject.Add(responseKey, value);
 					}
 				}
 				catch (Exception cacheError)

--- a/Mage/Archivist/Archivist.cs
+++ b/Mage/Archivist/Archivist.cs
@@ -463,7 +463,11 @@ namespace Wizcorp.MageSDK.MageClient
 
 						// Add value to response
 						int responseKey = realQueryKeys[cacheKeyName];
-						responseArray[responseKey].Replace(GetCacheValue(cacheKeyName).Data);
+						var cacheValue = GetCacheValue(cacheKeyName);
+						if (cacheValue != null)
+						{
+							responseArray[responseKey].Replace(cacheValue.Data);
+						}
 					}
 				}
 				catch (Exception cacheError)
@@ -546,7 +550,11 @@ namespace Wizcorp.MageSDK.MageClient
 
 						// Add value to response
 						string responseKey = realQueryKeys[cacheKeyName];
-						responseObject.Add(responseKey, GetCacheValue(cacheKeyName).Data);
+						var cacheValue = GetCacheValue(cacheKeyName);
+						if (cacheValue != null)
+						{
+							responseObject.Add(responseKey, cacheValue.Data);
+						}
 					}
 				}
 				catch (Exception cacheError)

--- a/Mage/Archivist/VaultValue.cs
+++ b/Mage/Archivist/VaultValue.cs
@@ -32,7 +32,7 @@ namespace Wizcorp.MageSDK.MageClient
 				MediaType = mediaType;
 
 				// Set data based on media type
-				Data = Tome.Conjure(JToken.Parse((string)data));
+				Data = data != null ? Tome.Conjure(JToken.Parse((string)data)) : null;
 
 				// Bump the last written time
 				WrittenAt = DateTime.UtcNow;


### PR DESCRIPTION
# Description
Issue found with **Archivist.MGet** when using the flag ```optional = true```
in the current code, MGet crash on the first null element of the result and throw a **nullReferenceException**. 

This happen because this element with a null value is not saved in the cache.

# How to Test
In the following code, if any of the seasonId in queries doesn't exist in archivist, the MGet callback will return ```("NullReferenceException", null)```
```csharp
var queries = new JObject();

foreach (var seasonId in seasonIds) {
	var rankingHistory = new JObject() {
		{"topic", new JValue(topicId)}, {
			"index", new JObject() { {"rankingId", new JValue(seasonId) } }
		}
	};

	// Creating Query
	queries.Add(seasonId, rankingHistory);
}

// Add Option: Optional
var options = new JObject();
options.Add("optional", new JValue(true));

Mage.Archivist.MGet(queries, options, callback);
```

# Comment
* This PR is about MGet(), Archivist.Get() seems to not support this optional flag (and probably have the same cache issue). We should probably open a new issue to implement this feature later.
* Is it necessary to add something in the ```responseObject``` anyway?
* Does that solve the issue with Smartbeat?
* Is it fine and match the current JS Implementation ? @ronkorving @AlmirKadric 