### PR TITLE
Logging timeout to server

### DIFF
--- a/HTTPRequest/HTTPRequest.DotNet.cs
+++ b/HTTPRequest/HTTPRequest.DotNet.cs
@@ -46,7 +46,7 @@ namespace Wizcorp.MageSDK.Network.Http
 			// Start timeout timer
 			timeoutTimer = new Timer((object state) => {
 				this.Abort();
-				cb(new Exception("Request timed out"), null);
+				cb(new HttpRequestException("Request timed out", 504), null);
 			}, null, timeout, Timeout.Infinite);
 
 			// Initialize request instance

--- a/HTTPRequest/HTTPRequest.DotNet.cs
+++ b/HTTPRequest/HTTPRequest.DotNet.cs
@@ -46,7 +46,7 @@ namespace Wizcorp.MageSDK.Network.Http
 			// Start timeout timer
 			timeoutTimer = new Timer((object state) => {
 				this.Abort();
-				cb(new HttpRequestException("Request timed out", 504), null);
+				cb(new HttpRequestException("Request timed out", 0), null);
 			}, null, timeout, Timeout.Infinite);
 
 			// Initialize request instance

--- a/HTTPRequest/HTTPRequest.Unity.cs
+++ b/HTTPRequest/HTTPRequest.Unity.cs
@@ -79,7 +79,7 @@ namespace Wizcorp.MageSDK.Network.Http
 				{
 					// Timed out abort the request with timeout error
 					Abort();
-					cb(new HttpRequestException("Request timed out", 504), null);
+					cb(new HttpRequestException("Request timed out", 0), null);
 					yield break;
 				}
 

--- a/HTTPRequest/HTTPRequest.Unity.cs
+++ b/HTTPRequest/HTTPRequest.Unity.cs
@@ -79,7 +79,7 @@ namespace Wizcorp.MageSDK.Network.Http
 				{
 					// Timed out abort the request with timeout error
 					Abort();
-					cb(new Exception("Request timed out"), null);
+					cb(new HttpRequestException("Request timed out", 504), null);
 					yield break;
 				}
 


### PR DESCRIPTION
# Description
At the moment we are logging a client side time out to the Mage servers, this is wrong because of long polling and generating a time out when nothing comes back over the message stream.

I have set it as status code 0 so that it is recognizable we are killing the request and not the server.