### PR TITLE
responseHeaders can be null

### DIFF
--- a/HTTPRequest/HTTPRequest.Unity.cs
+++ b/HTTPRequest/HTTPRequest.Unity.cs
@@ -107,7 +107,7 @@ namespace Wizcorp.MageSDK.Network.Http
 			if (request.error != null)
 			{
 				var statusCode = 0;
-				if (request.responseHeaders.ContainsKey("STATUS"))
+				if (request.responseHeaders != null && request.responseHeaders.ContainsKey("STATUS"))
 				{
 					statusCode = int.Parse(request.responseHeaders["STATUS"].Split(' ')[1]);
 				}


### PR DESCRIPTION
Headers are null when the device cannot connect to the remote server (if the server is down or the device is offline).